### PR TITLE
RETURNキーワードに対して構文解析を行えるように実装

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -44,3 +44,11 @@ type Identifier struct {
 
 func (i *Identifier) expressionNode()      {}
 func (i *Identifier) TokenLiteral() string { return i.Token.Literal }
+
+type ReturnStatement struct {
+	Token       token.Token //token.RETRUN トークン
+	ReturnValue Expression
+}
+
+func (rs *ReturnStatement) statementNode()       {}
+func (rs *ReturnStatement) TokenLiteral() string { return rs.Token.Literal }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -60,6 +60,8 @@ func (p *Parser) parseStatement() ast.Statement {
 	switch p.currentToken.Type {
 	case token.LET:
 		return p.parseLetStatement()
+	case token.RETURN:
+		return p.parseReturnStatement()
 	default:
 		return nil
 	}
@@ -76,6 +78,16 @@ func (p *Parser) parseLetStatement() *ast.LetStatement {
 		return nil
 	}
 
+	// TODO セミコロンに遭遇するまで式を読み飛ばしてしまっている
+	for !p.currentTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+	return stmt
+}
+
+func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
+	stmt := &ast.ReturnStatement{Token: p.currentToken}
+	p.nextToken()
 	// TODO セミコロンに遭遇するまで式を読み飛ばしてしまっている
 	for !p.currentTokenIs(token.SEMICOLON) {
 		p.nextToken()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -74,3 +74,30 @@ func checkParserErrors(t *testing.T, p *Parser) {
 	}
 	t.FailNow()
 }
+
+func TestReturnStatements(t *testing.T) {
+	input := `
+	return 5;
+	return 10
+	return 993322
+	`
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 3 {
+		t.Fatalf("program.Statements does not contain 3 statements. got=%d", len(program.Statements))
+	}
+	for _, stmt := range program.Statements {
+		returnStmt, ok := stmt.(*ast.ReturnStatement)
+		if !ok {
+			t.Errorf("stmt not *ast.ReturnStatement. got=%T", stmt)
+			continue
+		}
+		if returnStmt.TokenLiteral() != "return" {
+			t.Errorf("returnStmt.TokenLiteral not 'return', got %q", returnStmt.TokenLiteral())
+		}
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -78,8 +78,8 @@ func checkParserErrors(t *testing.T, p *Parser) {
 func TestReturnStatements(t *testing.T) {
 	input := `
 	return 5;
-	return 10
-	return 993322
+	return 10;
+	return 993322;
 	`
 	l := lexer.New(input)
 	p := New(l)


### PR DESCRIPTION
# やったこと
LETキーワードの実装を元に、RETURNキーワードの構文解析を実装

# やってないこと
- return キーワードの後ろに式があることを確認する
- return valueを認識する