### PR TITLE
if文の構文解析器の作成

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -167,7 +167,7 @@ func (b *Boolean) String() string       { return b.Token.Literal }
 type IfExpression struct {
 	Token       token.Token
 	Condition   Expression
-	Conseqence  *BlockStatement
+	Consequence *BlockStatement
 	Alternative *BlockStatement
 }
 
@@ -178,7 +178,7 @@ func (ie *IfExpression) String() string {
 	out.WriteString("if")
 	out.WriteString(ie.Condition.String())
 	out.WriteString(" ")
-	out.WriteString(ie.Conseqence.String())
+	out.WriteString(ie.Consequence.String())
 	if ie.Alternative != nil {
 
 		out.WriteString("else ")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -96,7 +96,7 @@ func (p *Parser) parseIfExpression() ast.Expression {
 		return nil
 	}
 
-	expression.Conseqence = p.parseBlockStatement()
+	expression.Consequence = p.parseBlockStatement()
 
 	if p.peekTokenIs(token.ELSE) {
 		p.nextToken()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -507,16 +507,16 @@ func TestIfExpredssiion(t *testing.T) {
 		return
 	}
 
-	if len(exp.Conseqence.Statements) != 1 {
-		t.Errorf("conseqence is not 1 statements. got=%d\n", len(exp.Conseqence.Statements))
+	if len(exp.Consequence.Statements) != 1 {
+		t.Errorf("consequence is not 1 statements. got=%d\n", len(exp.Consequence.Statements))
 	}
 
-	conseqence, ok := exp.Conseqence.Statements[0].(*ast.ExpressionStatement)
+	consequence, ok := exp.Consequence.Statements[0].(*ast.ExpressionStatement)
 	if !ok {
-		t.Fatalf("Statements[0] is not ast.ExpresssionStatements. got=%T", exp.Conseqence.Statements[0])
+		t.Fatalf("Statements[0] is not ast.ExpresssionStatements. got=%T", exp.Consequence.Statements[0])
 	}
 
-	if !testIdentifier(t, conseqence.Expression, "x") {
+	if !testIdentifier(t, consequence.Expression, "x") {
 		return
 	}
 	if exp.Alternative != nil {
@@ -552,15 +552,15 @@ func TestIfElseExpression(t *testing.T) {
 		return
 	}
 
-	if len(exp.Conseqence.Statements) != 1 {
+	if len(exp.Consequence.Statements) != 1 {
 		t.Errorf("consequence is not 1 statements. got=%d\n",
-			len(exp.Conseqence.Statements))
+			len(exp.Consequence.Statements))
 	}
 
-	consequence, ok := exp.Conseqence.Statements[0].(*ast.ExpressionStatement)
+	consequence, ok := exp.Consequence.Statements[0].(*ast.ExpressionStatement)
 	if !ok {
 		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
-			exp.Conseqence.Statements[0])
+			exp.Consequence.Statements[0])
 	}
 
 	if !testIdentifier(t, consequence.Expression, "x") {


### PR DESCRIPTION
##使い方
- if ( 条件式 ) { 処理 }
- if ( 条件式 ) { 処理 }  else { 処理 }
を構文解析できるようにした。

この言語において、if文は式のため、値を生成する。
`x = if (x > y) { x } else { y }`
のような使い方もできる。
(代入されるのは最後に評価された値)

##やったこと
- ifノードのデータ型を定義
- if文の構文解析関数を作成
- テストを作成
- else処理の実装