### PR TITLE
return文の評価実装

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"fmt"
 	"monkey/ast"
 	"monkey/object"
 )
@@ -181,4 +182,8 @@ func evalMinusPrefixOperatorExpression(right object.Object) object.Object {
 	}
 	value := right.(*object.Integer).Value
 	return &object.Integer{Value: -value}
+}
+
+func newError(format string, a ...interface{}) *object.Error {
+	return &object.Error{Message: fmt.Sprintf(format, a...)}
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -31,7 +31,7 @@ func Eval(node ast.Node) object.Object {
 		return evalInfixExpression(node.Operator, left, right)
 
 	case *ast.BlockStatement:
-		return evalStatements(node.Statements)
+		return evalBlockStatement(node)
 
 	case *ast.IfExpression:
 		return evalIfExpression(node)
@@ -48,6 +48,18 @@ func Eval(node ast.Node) object.Object {
 		return nativeBoolToBooleanObject(node.Value)
 	}
 	return nil
+}
+
+func evalBlockStatement(block *ast.BlockStatement) object.Object {
+	var result object.Object
+
+	for _, statement := range block.Statements {
+		result = Eval(statement)
+		if result != nil && result.Type() == object.RETRUN_VALUE_OBJ {
+			return result
+		}
+	}
+	return result
 }
 
 func evalIfExpression(ie *ast.IfExpression) object.Object {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -56,8 +56,11 @@ func evalBlockStatement(block *ast.BlockStatement) object.Object {
 
 	for _, statement := range block.Statements {
 		result = Eval(statement)
-		if result != nil && result.Type() == object.RETRUN_VALUE_OBJ {
-			return result
+		if result != nil {
+			rt := result.Type()
+			if rt == object.RETRUN_VALUE_OBJ || rt == object.ERRIE_OBJ {
+				return result
+			}
 		}
 	}
 	return result
@@ -140,8 +143,15 @@ func evalProgram(program *ast.Program) object.Object {
 	for _, statement := range program.Statements {
 		result = Eval(statement)
 
-		if returnValue, ok := result.(*object.ReturnValue); ok {
-			return returnValue.Value
+		// if returnValue, ok := result.(*object.ReturnValue); ok {
+		// 	return returnValue.Value
+		// }
+
+		switch result := result.(type) {
+		case *object.ReturnValue:
+			return result.Value
+		case *object.Error:
+			return result
 		}
 	}
 	return result

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -36,6 +36,10 @@ func Eval(node ast.Node) object.Object {
 	case *ast.IfExpression:
 		return evalIfExpression(node)
 
+	case *ast.ReturnStatement:
+		val := Eval(node.ReturnValue)
+		return &object.ReturnValue{Value: val}
+
 	//式
 	case *ast.IntegerLiteral:
 		return &object.Integer{Value: node.Value}
@@ -120,6 +124,10 @@ func evalStatements(stmts []ast.Statement) object.Object {
 
 	for _, statement := range stmts {
 		result = Eval(statement)
+
+		if returnValue, ok := result.(*object.ReturnValue); ok {
+			return returnValue.Value
+		}
 	}
 	return result
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -16,7 +16,7 @@ func Eval(node ast.Node) object.Object {
 
 	//文
 	case *ast.Program:
-		return evalStatements(node.Statements)
+		return evalProgram(node)
 
 	case *ast.ExpressionStatement:
 		return Eval(node.Expression)
@@ -131,10 +131,10 @@ func evalIntegerInfixExpression(
 	}
 }
 
-func evalStatements(stmts []ast.Statement) object.Object {
+func evalProgram(program *ast.Program) object.Object {
 	var result object.Object
 
-	for _, statement := range stmts {
+	for _, statement := range program.Statements {
 		result = Eval(statement)
 
 		if returnValue, ok := result.(*object.ReturnValue); ok {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -99,8 +99,10 @@ func evalInfixExpression(
 		return nativeBoolToBooleanObject(left == right)
 	case operator == "!=":
 		return nativeBoolToBooleanObject(left != right)
+	case left.Type() != right.Type():
+		return newError("type mismatch: %s %s %s", left.Type(), operator, right.Type())
 	default:
-		return NULL
+		return newError("unknown operator: %s %s %s", left.Type(), operator, right.Type())
 	}
 }
 
@@ -128,7 +130,7 @@ func evalIntegerInfixExpression(
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal != rightVal)
 	default:
-		return NULL
+		return newError("unknown operator: %s %s %s", left.Type(), operator, right.Type())
 	}
 }
 
@@ -159,7 +161,7 @@ func evalPrefixExpression(operator string, right object.Object) object.Object {
 	case "-":
 		return evalMinusPrefixOperatorExpression(right)
 	default:
-		return NULL
+		return newError("unknown operator: %s%s", operator, right.Type())
 	}
 }
 
@@ -178,7 +180,7 @@ func evalBangOperatorExpression(right object.Object) object.Object {
 
 func evalMinusPrefixOperatorExpression(right object.Object) object.Object {
 	if right.Type() != object.INTEGER_OBJ {
-		return NULL
+		return newError("unknown operator: -%s", right.Type())
 	}
 	value := right.(*object.Integer).Value
 	return &object.Integer{Value: -value}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -150,3 +150,20 @@ func testNullObject(t *testing.T, obj object.Object) bool {
 	}
 	return true
 }
+
+func TestReturnStatments(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int64
+	}{
+		{"return 10;", 10},
+		{"return 10; 9;", 10},
+		{"return 2 * 5; 9;", 10},
+		{"9; return 2*5; 9;", 10},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		testIntegerObject(t, evaluated, tt.expected)
+	}
+}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -177,3 +177,59 @@ func TestReturnStatments(t *testing.T) {
 		testIntegerObject(t, evaluated, tt.expected)
 	}
 }
+
+func TestErrorHandling(t *testing.T) {
+	tests := []struct {
+		input           string
+		expectedMessage string
+	}{
+		{
+			"5 + true;",
+			"type mismatch: INTEGER + BOOLEAN",
+		},
+		{
+			"5 + true; 5;",
+			"type mismatch: INTEGER + BOOLEAN",
+		},
+		{
+			"-true",
+			"unknown operator: -BOOLEAN:",
+		},
+		{
+			"true + false",
+			"unknown operator: BOOLEAN + BOOLEAN",
+		},
+		{
+			"5; true + false; ;",
+			"unknown operator: BOOLEAN + BOOLEAN",
+		},
+		{
+			"if(10 > 1) { true + false; }",
+			"unknown operator: BOOLEAN + BOOLEAN",
+		},
+		{
+			`
+			if(10 > 1) {
+				if (10 > 1){
+					return true + false;
+				}
+				return 1;
+			}
+			`,
+			"unknown operator: BOOLEAN + BOOLEAN",
+		},
+	}
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		errObj, ok := evaluated.(*object.Error)
+		if !ok {
+			t.Errorf("no error object returned. got=%T(%+v)", evaluated, evaluated)
+			continue
+		}
+
+		if errObj.Message != tt.expectedMessage {
+			t.Errorf("wrong error message. expected=%q, got=%q", tt.expectedMessage, errObj.Message)
+		}
+	}
+}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -160,6 +160,16 @@ func TestReturnStatments(t *testing.T) {
 		{"return 10; 9;", 10},
 		{"return 2 * 5; 9;", 10},
 		{"9; return 2*5; 9;", 10},
+		{`
+		if (10 > 1){
+			if(10 > 1){
+				return 10;
+			}
+			return 1;
+		}
+		`,
+			10,
+		},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -193,14 +193,14 @@ func TestErrorHandling(t *testing.T) {
 		},
 		{
 			"-true",
-			"unknown operator: -BOOLEAN:",
+			"unknown operator: -BOOLEAN",
 		},
 		{
 			"true + false",
 			"unknown operator: BOOLEAN + BOOLEAN",
 		},
 		{
-			"5; true + false; ;",
+			"5; true + false; 5",
 			"unknown operator: BOOLEAN + BOOLEAN",
 		},
 		{

--- a/object/object.go
+++ b/object/object.go
@@ -5,9 +5,10 @@ import "fmt"
 type ObjectType string
 
 const (
-	INTEGER_OBJ = "INTEGER"
-	BOOLEAN_OBJ = "BOOLEAN"
-	NULL_OBJ    = "NULL"
+	INTEGER_OBJ      = "INTEGER"
+	BOOLEAN_OBJ      = "BOOLEAN"
+	NULL_OBJ         = "NULL"
+	RETRUN_VALUE_OBJ = "RETURN_VALUE"
 )
 
 type Object interface {
@@ -33,3 +34,10 @@ type Null struct{}
 
 func (n *Null) Type() ObjectType { return NULL_OBJ }
 func (n *Null) Inspect() string  { return "null" }
+
+type ReturnValue struct {
+	Value Object
+}
+
+func (rv *ReturnValue) Type() ObjectType { return RETRUN_VALUE_OBJ }
+func (rv *ReturnValue) Inspect() string  { return rv.Value.Inspect() }

--- a/object/object.go
+++ b/object/object.go
@@ -9,6 +9,7 @@ const (
 	BOOLEAN_OBJ      = "BOOLEAN"
 	NULL_OBJ         = "NULL"
 	RETRUN_VALUE_OBJ = "RETURN_VALUE"
+	ERRIE_OBJ        = "ERROR"
 )
 
 type Object interface {
@@ -41,3 +42,10 @@ type ReturnValue struct {
 
 func (rv *ReturnValue) Type() ObjectType { return RETRUN_VALUE_OBJ }
 func (rv *ReturnValue) Inspect() string  { return rv.Value.Inspect() }
+
+type Error struct {
+	Message string
+}
+
+func (e *Error) Type() ObjectType { return ERRIE_OBJ }
+func (e *Error) Inspect() string  { return "ERROR : " + e.Message }


### PR DESCRIPTION
## やったこと
- object.ReturnValueの作成
- テストの作成(シンプルなreturn文 `return 10;`)
- return文の評価の実装
- ネストしたブロック文の中のreturn文のテストの作成
- ネストに対応したブロック文におけるreturn文の評価を追加実装(注1)

## 注1
<img width="1015" alt="スクリーンショット 2021-11-13 13 00 41" src="https://user-images.githubusercontent.com/84895022/141606555-4966f494-0f72-4f45-ac75-a525c3dd686f.png">
ネストに対応していない実装だと、
~~~
if(true){
    if(true){
        return 10;
    }
    return 1;
}
~~~
のようなケースでは1が返ってきてしまう。
これは、10がReturnValueとしてではなく、アンラップされたintの値が渡されてしまい、ネストされたブロック文以降も引き続き評価してしまうからである。
アンラップせず、objectとして渡すことで正しい評価が行える。