### PR TITLE
配列を使えるようにした

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -288,8 +288,8 @@ type IndexExpression struct {
 	Index Expression
 }
 
-func (ie *IndexExpression) expressionNode()     {}
-func (ie *IndexExpression) TokenLitera() string { return ie.Token.Literal }
+func (ie *IndexExpression) expressionNode()      {}
+func (ie *IndexExpression) TokenLiteral() string { return ie.Token.Literal }
 func (ie *IndexExpression) String() string {
 	var out bytes.Buffer
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -281,3 +281,23 @@ func (al *ArrayLiteral) String() string {
 
 	return out.String()
 }
+
+type IndexExpression struct {
+	Token token.Token //'['トークン
+	Left  Expression
+	Index Expression
+}
+
+func (ie *IndexExpression) expressionNode()     {}
+func (ie *IndexExpression) TokenLitera() string { return ie.Token.Literal }
+func (ie *IndexExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("(")
+	out.WriteString(ie.Left.String())
+	out.WriteString("[")
+	out.WriteString(ie.Index.String())
+	out.WriteString("])")
+
+	return out.String()
+}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -259,3 +259,25 @@ type StringLiteral struct {
 func (sl *StringLiteral) expressionNode()      {}
 func (sl *StringLiteral) TokenLiteral() string { return sl.Token.Literal }
 func (sl *StringLiteral) String() string       { return sl.Token.Literal }
+
+type ArrayLiteral struct {
+	Token    token.Token //'['トークン
+	Elements []Expression
+}
+
+func (al *ArrayLiteral) expressionNode()      {}
+func (al *ArrayLiteral) TokenLiteral() string { return al.Token.Literal }
+func (al *ArrayLiteral) String() string {
+	var out bytes.Buffer
+
+	elements := []string{}
+	for _, el := range al.Elements {
+		elements = append(elements, el.String())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ","))
+	out.WriteString("]")
+
+	return out.String()
+}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -276,7 +276,7 @@ func (al *ArrayLiteral) String() string {
 	}
 
 	out.WriteString("[")
-	out.WriteString(strings.Join(elements, ","))
+	out.WriteString(strings.Join(elements, ", "))
 	out.WriteString("]")
 
 	return out.String()

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -9,6 +9,8 @@ var builtins = map[string]*object.Builtin{
 				return newError("wrong number of arguments. got=%d, want=1", len(args))
 			}
 			switch arg := args[0].(type) {
+			case *object.Array:
+				return &object.Integer{Value: int64(len(arg.Elements))}
 			case *object.String:
 				return &object.Integer{Value: int64(len(arg.Value))}
 			default:

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -18,4 +18,20 @@ var builtins = map[string]*object.Builtin{
 			}
 		},
 	},
+	"first": &object.Builtin{
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			if args[0].Type() != object.ARRAY_OBJ {
+				return newError("argument to `first` must be ARRAY, got %s", args[0].Type())
+			}
+			arr := args[0].(*object.Array)
+			if len(arr.Elements) > 0 {
+				return arr.Elements[0]
+			}
+
+			return NULL
+		},
+	},
 }

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -72,4 +72,22 @@ var builtins = map[string]*object.Builtin{
 			return NULL
 		},
 	},
+
+	"push": &object.Builtin{
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return newError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			if args[0].Type() != object.ARRAY_OBJ {
+				return newError("argument to `push` must be ARRAY, got %s", args[0].Type())
+			}
+			arr := args[0].(*object.Array)
+			length := len(arr.Elements)
+
+			newElements := make([]object.Object, length+1, length+1)
+			copy(newElements, arr.Elements)
+			newElements[length] = args[1]
+			return &object.Array{Elements: newElements}
+		},
+	},
 }

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -34,4 +34,22 @@ var builtins = map[string]*object.Builtin{
 			return NULL
 		},
 	},
+
+	"last": &object.Builtin{
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			if args[0].Type() != object.ARRAY_OBJ {
+				return newError("argument to `last` must be ARRAY, got %s", args[0].Type())
+			}
+			arr := args[0].(*object.Array)
+			length := len(arr.Elements)
+			if length > 0 {
+				return arr.Elements[length-1]
+			}
+
+			return NULL
+		},
+	},
 }

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -52,4 +52,24 @@ var builtins = map[string]*object.Builtin{
 			return NULL
 		},
 	},
+
+	"rest": &object.Builtin{
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			if args[0].Type() != object.ARRAY_OBJ {
+				return newError("argument to `rest` must be ARRAY, got %s", args[0].Type())
+			}
+			arr := args[0].(*object.Array)
+			length := len(arr.Elements)
+			if length > 0 {
+				newElements := make([]object.Object, length-1, length-1)
+				copy(newElements, arr.Elements[1:length])
+				return &object.Array{Elements: newElements}
+			}
+
+			return NULL
+		},
+	},
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -89,6 +89,13 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 
 	case *ast.StringLiteral:
 		return &object.String{Value: node.Value}
+
+	case *ast.ArrayLiteral:
+		elements := evalExpressions(node.Elements, env)
+		if len(elements) == 1 && isError(elements[0]) {
+			return elements[0]
+		}
+		return &object.Array{Elements: elements}
 	}
 	return nil
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -96,6 +96,17 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 			return elements[0]
 		}
 		return &object.Array{Elements: elements}
+
+	case *ast.IndexExpression:
+		left := Eval(node.Left, env)
+		if isError(left) {
+			return left
+		}
+		index := Eval(node.Index, env)
+		if isError(index) {
+			return index
+		}
+		return evalIndexExpression(left, index)
 	}
 	return nil
 }
@@ -321,4 +332,25 @@ func evalStringInfixExpression(operator string, left object.Object, right object
 	leftVal := left.(*object.String).Value
 	rightVal := right.(*object.String).Value
 	return &object.String{Value: leftVal + rightVal}
+}
+
+func evalIndexExpression(left, index object.Object) object.Object {
+	switch {
+	case left.Type() == object.ARRAY_OBJ && index.Type() == object.INTEGER_OBJ:
+		return evalArrayIndexExpression(left, index)
+	default:
+		return newError("index operator not supported: %s", left.Type())
+	}
+}
+
+func evalArrayIndexExpression(array, index object.Object) object.Object {
+	arrayObject := array.(*object.Array)
+	idx := index.(*object.Integer).Value
+	max := int64(len(arrayObject.Elements) - 1)
+
+	if idx < 0 || idx > max {
+		return NULL
+	}
+
+	return arrayObject.Elements[idx]
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -347,7 +347,7 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`rest(35)`, "argument to `rest` must be ARRAY, got INTEGER"},
 		{`push([1, 2 ,3],5)`, []int{1, 2, 3, 5}},
 		{`push([],1)`, []int{1}},
-		{`push("hello")`, "argument to `first` must be ARRAY, got STRING"},
+		{`push("hello",1)`, "argument to `push` must be ARRAY, got STRING"},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -331,6 +331,10 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`len("hello world")`, 11},
 		{`len(1)`, "argument to `len` not supported, got INTEGER"},
 		{`len("one", "two")`, "wrong number of arguments. got=2, want=1"},
+		{`first([1, 2 ,3])`, 1},
+		{`first([])`, nil},
+		{`first("hello")`, "argument to `first` must be ARRAY, got STRING"},
+		{`first([1, 2, 3],[4, 5, 6])`, "wrong number of arguments. got=2, want=1"},
 	}
 
 	for _, tt := range tests {
@@ -348,6 +352,8 @@ func TestBuiltinFunctions(t *testing.T) {
 			if errObj.Message != expected {
 				t.Errorf("wrong error message. expected=%q,got=%q", expected, errObj.Message)
 			}
+		case nil:
+			testNullObject(t, evaluated)
 		}
 	}
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -339,6 +339,12 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`last([])`, nil},
 		{`last("hello")`, "argument to `last` must be ARRAY, got STRING"},
 		{`last([1, 2, 3],[4, 5, 6])`, "wrong number of arguments. got=2, want=1"},
+		{`rest([1, 2, 3])`, `[2, 3]`},
+		{`rest(rest([1, 2, 3]))`, `[3]`},
+		{`rest(rest(rest([1, 2, 3])))`, `[]`},
+		{`rest(rest(rest(rest([1, 2, 3]))))`, nil},
+		{`rest([1, 2, 3],[4, 5, 6])`, "wrong number of arguments. got=2, want=1"},
+		{`rest(35)`, "argument to `rest` must be ARRAY, got INTEGER"},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -339,9 +339,9 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`last([])`, nil},
 		{`last("hello")`, "argument to `last` must be ARRAY, got STRING"},
 		{`last([1, 2, 3],[4, 5, 6])`, "wrong number of arguments. got=2, want=1"},
-		{`rest([1, 2, 3])`, `[2, 3]`},
-		{`rest(rest([1, 2, 3]))`, `[3]`},
-		{`rest(rest(rest([1, 2, 3])))`, `[]`},
+		{`rest([1, 2, 3])`, []int{2, 3}},
+		{`rest(rest([1, 2, 3]))`, []int{3}},
+		{`rest(rest(rest([1, 2, 3])))`, []int{}},
 		{`rest(rest(rest(rest([1, 2, 3]))))`, nil},
 		{`rest([1, 2, 3],[4, 5, 6])`, "wrong number of arguments. got=2, want=1"},
 		{`rest(35)`, "argument to `rest` must be ARRAY, got INTEGER"},
@@ -361,6 +361,18 @@ func TestBuiltinFunctions(t *testing.T) {
 			}
 			if errObj.Message != expected {
 				t.Errorf("wrong error message. expected=%q,got=%q", expected, errObj.Message)
+			}
+		case []int:
+			array, ok := evaluated.(*object.Array)
+			if !ok {
+				t.Errorf("object is not Array. got=%T (%+v)", evaluated, evaluated)
+			}
+			if len(array.Elements) != len(expected) {
+				t.Errorf("wrong number of elements. want=%d, got=%d", len(array.Elements), len(expected))
+				continue
+			}
+			for i, expectedElem := range expected {
+				testIntegerObject(t, array.Elements[i], int64(expectedElem))
 			}
 		case nil:
 			testNullObject(t, evaluated)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -335,6 +335,10 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`first([])`, nil},
 		{`first("hello")`, "argument to `first` must be ARRAY, got STRING"},
 		{`first([1, 2, 3],[4, 5, 6])`, "wrong number of arguments. got=2, want=1"},
+		{`last([1, 2 ,3])`, 3},
+		{`last([])`, nil},
+		{`last("hello")`, "argument to `last` must be ARRAY, got STRING"},
+		{`last([1, 2, 3],[4, 5, 6])`, "wrong number of arguments. got=2, want=1"},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -351,3 +351,22 @@ func TestBuiltinFunctions(t *testing.T) {
 		}
 	}
 }
+
+func TestArrayLiterals(t *testing.T) {
+	input := "[1, 2 * 2, 3 + 3]"
+
+	evaluated := testEval(input)
+	result, ok := evaluated.(*object.Array)
+	if !ok {
+		t.Fatalf("object is not Array. got=%T (%+v)", evaluated, evaluated)
+	}
+
+	if len(result.Elements) != 3 {
+		t.Fatalf("array has wrong num of elements. got=%d",
+			len(result.Elements))
+	}
+
+	testIntegerObject(t, result.Elements[0], 1)
+	testIntegerObject(t, result.Elements[1], 4)
+	testIntegerObject(t, result.Elements[2], 6)
+}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -345,6 +345,9 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`rest(rest(rest(rest([1, 2, 3]))))`, nil},
 		{`rest([1, 2, 3],[4, 5, 6])`, "wrong number of arguments. got=2, want=1"},
 		{`rest(35)`, "argument to `rest` must be ARRAY, got INTEGER"},
+		{`push([1, 2 ,3],5)`, []int{1, 2, 3, 5}},
+		{`push([],1)`, []int{1}},
+		{`push("hello")`, "argument to `first` must be ARRAY, got STRING"},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -370,3 +370,61 @@ func TestArrayLiterals(t *testing.T) {
 	testIntegerObject(t, result.Elements[1], 4)
 	testIntegerObject(t, result.Elements[2], 6)
 }
+
+func TestArrayIndexExpressions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			"[1, 2, 3][0]",
+			1,
+		},
+		{
+			"[1, 2, 3][1]",
+			2,
+		},
+		{
+			"[1, 2, 3][2]",
+			3,
+		},
+		{
+			"let i = 0; [1][i];",
+			1,
+		},
+		{
+			"[1, 2, 3][1 + 1];",
+			3,
+		},
+		{
+			"let myArray = [1, 2, 3]; myArray[2];",
+			3,
+		},
+		{
+			"let myArray = [1, 2, 3]; myArray[0] + myArray[1] + myArray[2];",
+			6,
+		},
+		{
+			"let myArray = [1, 2, 3]; let i = myArray[0]; myArray[i]",
+			2,
+		},
+		{
+			"[1, 2, 3][3]",
+			nil,
+		},
+		{
+			"[1, 2, 3][-1]",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		integer, ok := tt.expected.(int)
+		if ok {
+			testIntegerObject(t, evaluated, int64(integer))
+		} else {
+			testNullObject(t, evaluated)
+		}
+	}
+}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -87,6 +87,10 @@ func (l *Lexer) NextToken() token.Token {
 	case '"':
 		tok.Type = token.STRING
 		tok.Literal = l.readString()
+	case '[':
+		tok = newToken(token.LBRACKET, l.ch)
+	case ']':
+		tok = newToken(token.RBRACKET, l.ch)
 	default:
 		if isLetter(l.ch) {
 			tok.Literal = l.readIdentifier()

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -28,6 +28,7 @@ func TestNextToken(t *testing.T) {
 	10 != 9;
 	"foobar"
 	"foo bar"
+	[1, 2];
 	`
 
 	tests := []struct {
@@ -109,6 +110,12 @@ func TestNextToken(t *testing.T) {
 		{token.SEMICOLON, ";"},
 		{token.STRING, "foobar"},
 		{token.STRING, "foo bar"},
+		{token.LBEACKET, "["},
+		{token.INT, "1"},
+		{token.COMMA, ","},
+		{token.INT, "2"},
+		{token.RBRACKET, "]"},
+		{token.SEMICOLON, ";"},
 		{token.EOF, ""},
 	}
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -110,7 +110,7 @@ func TestNextToken(t *testing.T) {
 		{token.SEMICOLON, ";"},
 		{token.STRING, "foobar"},
 		{token.STRING, "foo bar"},
-		{token.LBEACKET, "["},
+		{token.LBRACKET, "["},
 		{token.INT, "1"},
 		{token.COMMA, ","},
 		{token.INT, "2"},

--- a/object/object.go
+++ b/object/object.go
@@ -18,6 +18,7 @@ const (
 	FUNCTION_OBJ     = "FUNCTION"
 	STRING_OBJ       = "STRING"
 	BUILTIN_OBJ      = "BUILTIN"
+	ARRAY_OBJ        = "ARRAY"
 )
 
 type Object interface {
@@ -97,3 +98,21 @@ type Builtin struct {
 
 func (b *Builtin) Type() ObjectType { return BUILTIN_OBJ }
 func (b *Builtin) Inspect() string  { return "builtin function" }
+
+type Array struct {
+	Elements []Object
+}
+
+func (arr *Array) Type() ObjectType { return ARRAY_OBJ }
+func (arr *Array) Inspect() string {
+	var out bytes.Buffer
+	elements := []string{}
+	for _, e := range arr.Elements {
+		elements = append(elements, e.Inspect())
+	}
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -76,6 +76,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.LT, p.parseInfixExpression)
 	p.registerInfix(token.GT, p.parseInfixExpression)
 	p.registerInfix(token.LPAREN, p.parseCallExpression)
+	p.registerInfix(token.LBRACKET, p.parseIndexExpression)
 
 	//2つのトークン読み込む。currentTokenとpeekTokenの両方がセットされる。
 	p.nextToken()
@@ -417,4 +418,13 @@ func (p *Parser) parseExpressionList(end token.TokenType) []ast.Expression {
 		return nil
 	}
 	return list
+}
+
+func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
+	exp := &ast.IndexExpression{Token: p.currentToken, Left: left}
+	p.nextToken()
+	if !p.expectPeek(token.RBRACKET) {
+		return nil
+	}
+	return exp
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -64,6 +64,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.IF, p.parseIfExpression)
 	p.registerPrefix(token.FUNCTION, p.parseFunctionLiteral)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
+	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
@@ -85,31 +86,8 @@ func New(l *lexer.Lexer) *Parser {
 
 func (p *Parser) parseCallExpression(function ast.Expression) ast.Expression {
 	exp := &ast.CallExpression{Token: p.currentToken, Function: function}
-	exp.Arguments = p.parseCallArguments()
+	exp.Arguments = p.parseExpressionList(token.RPAREN)
 	return exp
-}
-
-func (p *Parser) parseCallArguments() []ast.Expression {
-	args := []ast.Expression{}
-
-	if p.peekTokenIs(token.RPAREN) { //引数なし
-		p.nextToken()
-		return args
-	}
-
-	p.nextToken()
-	args = append(args, p.parseExpression(LOWEST))
-
-	for p.peekTokenIs(token.COMMA) {
-		p.nextToken()
-		p.nextToken()
-		args = append(args, p.parseExpression(LOWEST))
-	}
-
-	if !p.expectPeek(token.RPAREN) {
-		return nil
-	}
-	return args
 }
 
 func (p *Parser) parseFunctionLiteral() ast.Expression {
@@ -411,4 +389,32 @@ func (p *Parser) noPrefixParseFnError(t token.TokenType) {
 
 func (p *Parser) parseStringLiteral() ast.Expression {
 	return &ast.StringLiteral{Token: p.currentToken, Value: p.currentToken.Literal}
+}
+
+func (p *Parser) parseArrayLiteral() ast.Expression {
+	array := &ast.ArrayLiteral{Token: p.currentToken}
+	array.Elements = p.parseExpressionList(token.RBRACKET)
+	return array
+}
+
+func (p *Parser) parseExpressionList(end token.TokenType) []ast.Expression {
+	list := []ast.Expression{}
+
+	if p.peekTokenIs(end) {
+		p.nextToken()
+		return list
+	}
+	p.nextToken()
+	list = append(list, p.parseExpression(LOWEST))
+
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		list = append(list, p.parseExpression(LOWEST))
+	}
+
+	if !p.expectPeek(end) {
+		return nil
+	}
+	return list
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -33,6 +33,7 @@ const (
 	PRODUCT     // *
 	PREFIX      // -X OR !X
 	CALL        // myFunction(X)
+	INDEX       // array[index]
 )
 
 var precedences = map[token.TokenType]int{
@@ -45,6 +46,7 @@ var precedences = map[token.TokenType]int{
 	token.SLASH:    PRODUCT,
 	token.ASTERISK: PRODUCT,
 	token.LPAREN:   CALL,
+	token.LBRACKET: INDEX,
 }
 
 func New(l *lexer.Lexer) *Parser {
@@ -423,6 +425,7 @@ func (p *Parser) parseExpressionList(end token.TokenType) []ast.Expression {
 func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
 	exp := &ast.IndexExpression{Token: p.currentToken, Left: left}
 	p.nextToken()
+	exp.Index = p.parseExpression(LOWEST)
 	if !p.expectPeek(token.RBRACKET) {
 		return nil
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -725,3 +725,26 @@ func TestStringLiteralExpression(t *testing.T) {
 		t.Errorf("literal.Value not %q. got=%q", "hello world", literal.Value)
 	}
 }
+
+func TestParsingArrayLiterals(t *testing.T) {
+	input := "[1, 2 * 2, 3 + 3]"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	array, ok := stmt.Expression.(*ast.ArrayLiteral)
+	if !ok {
+		t.Fatalf("exp not ast.ArrayLiteral. got=%T", stmt.Expression)
+	}
+
+	if len(array.Elements) != 3 {
+		t.Fatalf("len(array.Elements) not 3. got=%d", len(array.Elements))
+	}
+
+	testIntegerLiteral(t, array.Elements[0], 1)
+	testInfixExpression(t, array.Elements[1], 2, "*", 2)
+	testInfixExpression(t, array.Elements[2], 3, "+", 3)
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -748,3 +748,25 @@ func TestParsingArrayLiterals(t *testing.T) {
 	testInfixExpression(t, array.Elements[1], 2, "*", 2)
 	testInfixExpression(t, array.Elements[2], 3, "+", 3)
 }
+
+func TestParsingIndexExpression(t *testing.T) {
+	input := "myArray[1 + 1]"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	indexExp, ok := stmt.Expression.(*ast.IndexExpression)
+	if !ok {
+		t.Fatalf("exp not *ast.IndexExpression. got=%T", stmt.Expression)
+	}
+
+	if !testIdentifier(t, indexExp.Left, "myArray") {
+		return
+	}
+	if !testInfixExpression(t, indexExp, 1, "+", 1) {
+		return
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -377,7 +377,7 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 		},
 		{
 			"add(a * b[2], b[1], 2 * [1, 2][1])",
-			"add((a * b[2]), (b[1]), (2 * ([1, 2][1])))",
+			"add((a * (b[2])), (b[1]), (2 * ([1, 2][1])))",
 		},
 	}
 
@@ -774,7 +774,7 @@ func TestParsingIndexExpression(t *testing.T) {
 	if !testIdentifier(t, indexExp.Left, "myArray") {
 		return
 	}
-	if !testInfixExpression(t, indexExp, 1, "+", 1) {
+	if !testInfixExpression(t, indexExp.Index, 1, "+", 1) {
 		return
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -371,6 +371,14 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 			"add(a + b + c * d / f + g)",
 			"add((((a + b) + ((c * d) / f)) + g))",
 		},
+		{
+			"a * [1, 2, 3, 4][b * c] * d",
+			"((a * ([1, 2, 3, 4][(b * c)])) * d)",
+		},
+		{
+			"add(a * b[2], b[1], 2 * [1, 2][1])",
+			"add((a * b[2]), (b[1]), (2 * ([1, 2][1])))",
+		},
 	}
 
 	for _, tt := range tests {

--- a/token/token.go
+++ b/token/token.go
@@ -55,7 +55,7 @@ const (
 	RPAREN   = ")"
 	LBRACE   = "{"
 	RBRACE   = "}"
-	LBEACKET = "["
+	LBRACKET = "["
 	RBRACKET = "]"
 
 	//キーワード

--- a/token/token.go
+++ b/token/token.go
@@ -51,10 +51,12 @@ const (
 	COMMA     = ","
 	SEMICOLON = ";"
 
-	LPAREN = "("
-	RPAREN = ")"
-	LBRACE = "{"
-	RBRACE = "}"
+	LPAREN   = "("
+	RPAREN   = ")"
+	LBRACE   = "{"
+	RBRACE   = "}"
+	LBEACKET = "["
+	RBRACKET = "]"
 
 	//キーワード
 	FUNCTION = "FUNCTION"


### PR DESCRIPTION
## できるようになったこと
- `let a = [1, "a", [1, 2 , 3], fn(x){x+x}]`のようにMonkeyに対応するリテラルや識別子を要素として格納する
- `a[2]` で添字演算子による要素へのアクセス
- `a` で配列の中身を全て表示 // [1, "a", [1, 2 , 3], fn(x){x+x}]
- 配列に対応した組み込み関数
    - `first([1, 2, 3]) // 1`
    - `last([1, 2, 3]) // 3`
    - `rest([1, 2, 3]) // [2, 3]`
    - `push([1, 2, 3], 5) //[1, 2, 3, 5]`